### PR TITLE
Fix missing strict types

### DIFF
--- a/src/Constraint/ExpectedProperites.php
+++ b/src/Constraint/ExpectedProperites.php
@@ -13,7 +13,7 @@ class ExpectedProperites extends AbstractConstraint
 
     public function run($value): bool
     {
-        return in_array($value, $this->allowedProperites);
+        return in_array($value, $this->allowedProperites, true);
     }
 
     public function getMetadata(): array


### PR DESCRIPTION
Fix wrong usage for PHP 7.4. `in_array` instruction needs to pass them strict type argument to work correctly.

**PHP 7.4**

```
in_array(0, ['some', 'string']);

returns true
```

**PHP 8.1**

```
in_array(0, ['some', 'string']);

returns false
```